### PR TITLE
Fixing kde neon size_bdiag/fdiag cursors

### DIFF
--- a/src/cursorList
+++ b/src/cursorList
@@ -94,3 +94,7 @@ x-cursor default
 wayland-cursor default
 zoom-in default
 zoom-out default
+ne-resize size_bdiag
+sw-resize size_bdiag
+nw-resize size_fdiag
+se-resize size_fdiag


### PR DESCRIPTION
KDE Neon use ne-resize/sw-resize/nw-resize/se-resize symlink instead of top-left/top-right etc. Breeze cursor theme is used as fallback in case of missed cursor.
Just adding new symlinks.